### PR TITLE
Added support for paths with spaces

### DIFF
--- a/src/jetbrainsdolphinplugin.cpp
+++ b/src/jetbrainsdolphinplugin.cpp
@@ -101,7 +101,7 @@ QList<QAction *> JetBrainsDolphinPlugin::actions(const KFileItemListProperties &
 void JetBrainsDolphinPlugin::openIDE(JetbrainsApplication *app)
 {
     Q_ASSERT(app);
-    const QString exec = app->executablePath + QLatin1Char(' ') + projectPath;
+    const QString exec = app->executablePath + QLatin1Char(' ') + QLatin1Char('"') + projectPath + QLatin1Char('"');
     auto job = new KIO::CommandLauncherJob(exec);
     job->start();
 }

--- a/src/jetbrainsdolphinplugin.cpp
+++ b/src/jetbrainsdolphinplugin.cpp
@@ -101,7 +101,7 @@ QList<QAction *> JetBrainsDolphinPlugin::actions(const KFileItemListProperties &
 void JetBrainsDolphinPlugin::openIDE(JetbrainsApplication *app)
 {
     Q_ASSERT(app);
-    const QString exec = app->executablePath + QLatin1Char(' ') + QLatin1Char('"') + projectPath + QLatin1Char('"');
+    const QString exec = app->executablePath + QLatin1Char(' ') + KShell::quoteArg(projectPath);
     auto job = new KIO::CommandLauncherJob(exec);
     job->start();
 }


### PR DESCRIPTION
Previously, opening a path would fail to open a path with spaces in it, instead opening multiple lite editors for the separated paths, this commit fixes that by wrapping the path with quotes in the execute string.