### PR TITLE
Correct spelling of 'Jetbrains' to 'JetBrains'

### DIFF
--- a/src/jetbrainsdolphinplugin.cpp
+++ b/src/jetbrainsdolphinplugin.cpp
@@ -81,7 +81,7 @@ QList<QAction *> JetBrainsDolphinPlugin::actions(const KFileItemListProperties &
             auto *menuAction = new KActionMenu(this);
             qWarning() << QStandardPaths::locate(QStandardPaths::GenericDataLocation, QStringLiteral("icons/jetbrains.png"));
             menuAction->setIcon(jetbrainsIcon);
-            menuAction->setText(QStringLiteral("Jetbrains"));
+            menuAction->setText(QStringLiteral("JetBrains"));
             for (int i = 0; i < apps.count(); ++i) {
                 const auto app = apps.at(i);
                 if (containsPath(app, projectPath)) {
@@ -119,7 +119,7 @@ QList<QAction *> JetBrainsDolphinPlugin::getDefaultActions()
     // create default menu
     auto *menuAction = new KActionMenu(this);
     menuAction->setIcon(jetbrainsIcon);
-    menuAction->setText(QStringLiteral("Jetbrains"));
+    menuAction->setText(QStringLiteral("JetBrains"));
     for (int i = 0; i < apps.count(); ++i) {
         const auto app = apps.at(i);
         auto action = new QAction(QIcon::fromTheme(app->iconPath), app->shortName, this);


### PR DESCRIPTION
Hi, thanks for your plugin and sorry for this mini PR. Just installed it via the AUR package and it works great so far! Just the spelling of JetBrains was a bit odd and [according to their website](https://www.jetbrains.com/company/brand/#company-brand-brand-guidelines-trademarks-list) they use a uppercase B.

I have tested this patch locally and it compiles and works on my end.